### PR TITLE
Clarifying instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ gulp.src('./dist/**')
 
 
 ### Publish a library
-Alternately, to publish a library (e.g. jQuery, Angular, etc.) to the CDN:
+To publish a library (e.g. jQuery, Angular, etc.) to the CDN:
 
 ```javascript
 var libPublisher = publisher.lib( options );
@@ -51,9 +51,7 @@ gulp.src('./lib/jquery/**')
 ```
 
 ### Publish to production
-To publish the released/production version of your app or library, simply change the `devTag` property to `version`.
-
-In your `options` variable:
+To publish the released/production version of your app or library, simply change the `devTag` property to `version` in your `options` variable:
 
 ```javascript
 var options = {
@@ -79,7 +77,7 @@ Both the `app()` and `lib()` publisher methods accept the following options:
 | version       | The released/production version of the app or library. Unlike devTag, this property must follow the guidelines in [Semantic Versioning](http://semver.org). |
 
 
-### Obtaining the CDN location
+### Get the app's location
 To get the final location of where the files are on the CDN:
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -37,9 +37,6 @@ gulp.src('./dist/**')
 	.pipe( appPublisher.getStream() );
 ```
 
-**Note**: Make sure the version number for your application follows the guideline specified in [Semantic Versioning](http://semver.org).
-
-
 ### Publish a library
 To publish a library (e.g. jQuery, Angular, etc.) to the CDN:
 
@@ -51,7 +48,10 @@ gulp.src('./lib/jquery/**')
 ```
 
 ### Publish to production
-To publish the released/production version of your app or library, simply change the `devTag` property to `version` in your `options` variable:
+To publish the released/production version of your app or library, you must change the `devTag` property to `version` and you must specify a valid version number that follows the guideline specified in [Semantic Versioning](http://semver.org).
+
+
+In your `options` variable, set the `version` tag with a valid version:
 
 ```javascript
 var options = {
@@ -63,8 +63,6 @@ var options = {
 	version: '4.2.1'
 };
 ```
-
-**Note**: Make sure the version number for your application follows the guideline specified in [Semantic Versioning](http://semver.org).
 
 ### Publishing options
 Both the `app()` and `lib()` publisher methods accept the following options:

--- a/README.md
+++ b/README.md
@@ -3,18 +3,21 @@
 [![Build status][ci-image]][ci-url]
 [![Coverage Status][coverage-image]][coverage-url]
 
-Utility for publishing free-range applications and libraries to our CDN
+A utility for publishing free-range applications and libraries to our CDN
 using [Gulp](http://www.gulpjs.com).
 
-## Usage
+## Installation
 
-Install `gulp-frau-publisher` as a dependency:
+Install `gulp-frau-publisher` as a dev dependency:
 
 ```shell
 npm install --save-dev gulp-frau-publisher
 ```
 
-To publish a free-range application:
+## Publishing to the CDN
+
+### Publish an app
+To publish a free-range application to the CDN:
 
 ```javascript
 var publisher = require('gulp-frau-publisher');
@@ -34,6 +37,10 @@ gulp.src('./dist/**')
 	.pipe( appPublisher.getStream() );
 ```
 
+**Note**: Make sure the version number for your application follows the guideline specified in [Semantic Versioning](http://semver.org).
+
+
+### Publish a library
 Alternately, to publish a library (e.g. jQuery, Angular, etc.) to the CDN:
 
 ```javascript
@@ -43,30 +50,37 @@ gulp.src('./lib/jquery/**')
 	.pipe( libPublisher.getStream() );
 ```
 
-To publish the release version of your app or library, simply change `devTag` property to `version`.
+### Publish to production
+To publish the released/production version of your app or library, simply change the `devTag` property to `version`.
 
 In your `options` variable:
 
 ```javascript
 var options = {
 	id: 'someID',
-	creds: require('./creds/keys.json'),
+	creds: {
+		"key": "AKITHISISSOMEKEYASDF",
+		"secret": "aCD233rDF232RANDOMSECRET12+32g"
+	},
 	version: '4.2.1'
 };
 ```
 
-Make sure the version follows the guideline to [Semantic Versioning](http://semver.org) of a valid version number.
+**Note**: Make sure the version number for your application follows the guideline specified in [Semantic Versioning](http://semver.org).
 
+### Publishing options
 Both the `app()` and `lib()` publisher methods accept the following options:
 
-| Property Name | Description |
+| Property | Description |
 | ------------- | ----------- |
-| id            | Unique name of the application or library. |
-| creds         | Credential key/secret. Do **not** commit the secret to source control. Either load it from a file (which is excluded from source control) or use an environment or command-line variable. |
-| devTag        | The development version of the application or library. |
-| version       | The release version of the application or library. Unlike devTag, this property must follow the guideline to Semantic Versioning. |
+| id            | Unique name of the app or library. |
+| creds         | Credentials key/secret for the specified app. Do **not** commit the secret to source control. Either load it from a file (which is excluded from source control) or use an environment or command-line variable. |
+| devTag        | The development version of the app or library. |
+| version       | The released/production version of the app or library. Unlike devTag, this property must follow the guidelines in [Semantic Versioning](http://semver.org). |
 
-To get the final location on the CDN of your files:
+
+### Obtaining the CDN location
+To get the final location of where the files are on the CDN:
 
 ```javascript
 var appPublisher = require('gulp-frau-publisher').app( options );


### PR DESCRIPTION
Clarified the instructions in the readme, including style, wording, and spelling.