### PR TITLE
Parameterize CDN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,53 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm
+
+*.iml
+
+## Directory-based project format:
+.idea/
+# if you remove the above rule, at least ignore the following:
+
+# User-specific stuff:
+# .idea/workspace.xml
+# .idea/tasks.xml
+# .idea/dictionaries
+
+# Sensitive or high-churn files:
+# .idea/dataSources.ids
+# .idea/dataSources.xml
+# .idea/sqlDataSources.xml
+# .idea/dynamic.xml
+# .idea/uiDesigner.xml
+
+# Gradle:
+# .idea/gradle.xml
+# .idea/libraries
+
+# Mongo Explorer plugin:
+# .idea/mongoSettings.xml
+
+## File-based project format:
+*.ipr
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+
+

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Both the `app()` and `lib()` publisher methods accept the following options:
 | devTag        | The development version of the app or library. |
 | version       | The released/production version of the app or library. Unlike devTag, this property must follow the guidelines in [Semantic Versioning](http://semver.org). |
 
+**Note**: Can also provide a `bucket` property in the creds object that is the name of an S3 bucket to upload to if you don't want to publish to the CDN.
+
 
 ### Get the app's location
 To get the final location of where the files are on the CDN:

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ var options = {
 Both the `app()` and `lib()` publisher methods accept the following options:
 
 **Options**
+
 | Property | Description |
 | ------------- | ----------- |
 | id            | Unique name of the app or library. |
@@ -76,11 +77,12 @@ Both the `app()` and `lib()` publisher methods accept the following options:
 | version       | The released/production version of the app or library. Unlike devTag, this property must follow the guidelines in [Semantic Versioning](http://semver.org). |
 
 **Creds**
+
 | Property | Description |
 | ------------- | ----------- |
 | key            | AWS key. |
 | secret         |  AWS Secret. Do **not** commit the secret to source control. Either load it from a file (which is excluded from source control) or use an environment or command-line variable. |
-| testBucket [optional] | S3 bucket to publish the app to. Leave undefined to upload to the production Brightspace CDN. |
+| testBucket *[optional]* | S3 bucket to publish the app to. Leave undefined to upload to the production Brightspace CDN. |
 
 ### Get the app's location
 To get the final location of where the files are on the CDN:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Both the `app()` and `lib()` publisher methods accept the following options:
 | ------------- | ----------- |
 | key            | AWS key. |
 | secret         |  AWS Secret. Do **not** commit the secret to source control. Either load it from a file (which is excluded from source control) or use an environment or command-line variable. |
-| bucket [optional] | S3 bucket to publish the app to. Leave undefined to upload to the production Brightspace CDN. |
+| testBucket [optional] | S3 bucket to publish the app to. Leave undefined to upload to the production Brightspace CDN. |
 
 ### Get the app's location
 To get the final location of where the files are on the CDN:

--- a/README.md
+++ b/README.md
@@ -67,15 +67,20 @@ var options = {
 ### Publishing options
 Both the `app()` and `lib()` publisher methods accept the following options:
 
+**Options**
 | Property | Description |
 | ------------- | ----------- |
 | id            | Unique name of the app or library. |
-| creds         | Credentials key/secret for the specified app. Do **not** commit the secret to source control. Either load it from a file (which is excluded from source control) or use an environment or command-line variable. |
+| creds         | AWS credentials for the specified app (see table below for properties).
 | devTag        | The development version of the app or library. |
 | version       | The released/production version of the app or library. Unlike devTag, this property must follow the guidelines in [Semantic Versioning](http://semver.org). |
 
-**Note**: Can also provide a `bucket` property in the creds object that is the name of an S3 bucket to upload to if you don't want to publish to the CDN.
-
+**Creds**
+| Property | Description |
+| ------------- | ----------- |
+| key            | AWS key. |
+| secret         |  AWS Secret. Do **not** commit the secret to source control. Either load it from a file (which is excluded from source control) or use an environment or command-line variable. |
+| bucket [optional] | S3 bucket to publish the app to. Leave undefined to upload to the production Brightspace CDN. |
 
 ### Get the app's location
 To get the final location of where the files are on the CDN:

--- a/src/optionsValidator.js
+++ b/src/optionsValidator.js
@@ -61,6 +61,12 @@ module.exports = function( opts ) {
 			};
 		},
 
+		getBaseLocation: function() {
+			validateOpts( opts );
+			var bucket = opts.creds.bucket;
+			return bucket ? 'https://s3.amazonaws.com/' + bucket + '/' : 'https://s.brightspace.com/';
+		},
+
 		getUploadPath: function() {
 			validateOpts( opts );
 			var devPath = getDevPath( opts );

--- a/src/optionsValidator.js
+++ b/src/optionsValidator.js
@@ -57,7 +57,7 @@ module.exports = function( opts ) {
 			return {
 				key: opts.creds.key,
 				secret: opts.creds.secret,
-				bucket: 'd2lprodcdn'
+				bucket: opts.creds.bucket || 'd2lprodcdn'
 			};
 		},
 

--- a/src/optionsValidator.js
+++ b/src/optionsValidator.js
@@ -57,15 +57,15 @@ module.exports = function( opts ) {
 			return {
 				key: opts.creds.key,
 				secret: opts.creds.secret,
-				bucket: opts.creds.bucket || 'd2lprodcdn'
+				testBucket: opts.creds.testBucket || 'd2lprodcdn'
 			};
 		},
 
 		getBaseLocation: function() {
 			validateOpts( opts );
-			var bucket = opts.creds.bucket;
-            if (bucket && bucket !== 'd2lprodcdn') {
-                return 'https://s3.amazonaws.com/' + bucket + '/';
+			var testBucket = opts.creds.testBucket;
+            if (testBucket && testBucket !== 'd2lprodcdn') {
+                return 'https://s3.amazonaws.com/' + testBucket + '/';
             } else {
                 return 'https://s.brightspace.com/';
             }

--- a/src/optionsValidator.js
+++ b/src/optionsValidator.js
@@ -64,11 +64,11 @@ module.exports = function( opts ) {
 		getBaseLocation: function() {
 			validateOpts( opts );
 			var testBucket = opts.creds.testBucket;
-            if (testBucket && testBucket !== 'd2lprodcdn') {
-                return 'https://s3.amazonaws.com/' + testBucket + '/';
-            } else {
-                return 'https://s.brightspace.com/';
-            }
+			if (testBucket && testBucket !== 'd2lprodcdn') {
+				return 'https://s3.amazonaws.com/' + testBucket + '/';
+			} else {
+				return 'https://s.brightspace.com/';
+			}
 		},
 
 		getUploadPath: function() {

--- a/src/optionsValidator.js
+++ b/src/optionsValidator.js
@@ -64,7 +64,11 @@ module.exports = function( opts ) {
 		getBaseLocation: function() {
 			validateOpts( opts );
 			var bucket = opts.creds.bucket;
-			return bucket ? 'https://s3.amazonaws.com/' + bucket + '/' : 'https://s.brightspace.com/';
+            if (bucket && bucket !== 'd2lprodcdn') {
+                return 'https://s3.amazonaws.com/' + bucket + '/';
+            } else {
+                return 'https://s.brightspace.com/';
+            }
 		},
 
 		getUploadPath: function() {

--- a/src/optionsValidator.js
+++ b/src/optionsValidator.js
@@ -57,7 +57,7 @@ module.exports = function( opts ) {
 			return {
 				key: opts.creds.key,
 				secret: opts.creds.secret,
-				testBucket: opts.creds.testBucket || 'd2lprodcdn'
+				bucket: opts.creds.testBucket || 'd2lprodcdn'
 			};
 		},
 

--- a/src/publisher.js
+++ b/src/publisher.js
@@ -27,9 +27,9 @@ function helper( opts, initialPath ) {
 
 		},
 		getLocation: function() {
-            var options = optionsValidator( opts );
-            return options.getBaseLocation() + options.getUploadPath();
-        }
+			var options = optionsValidator( opts );
+			return options.getBaseLocation() + options.getUploadPath();
+		}
 	};
 }
 

--- a/src/publisher.js
+++ b/src/publisher.js
@@ -27,8 +27,10 @@ function helper( opts, initialPath ) {
 
 		},
 		getLocation: function() {
-			var options = optionsValidator( opts );
-			return 'https://s.brightspace.com/' + options.getUploadPath();
+            var options = optionsValidator( opts );
+            var bucket = options.getCreds().bucket;
+            var base = bucket === 'd2lprodcdn' ? 'https://s.brightspace.com/' : 'https://s3.amazonaws.com/' + bucket + '/';
+            return base + options.getUploadPath();
 		}
 	};
 }

--- a/src/publisher.js
+++ b/src/publisher.js
@@ -28,10 +28,8 @@ function helper( opts, initialPath ) {
 		},
 		getLocation: function() {
             var options = optionsValidator( opts );
-            var bucket = options.getCreds().bucket;
-            var base = bucket === 'd2lprodcdn' ? 'https://s.brightspace.com/' : 'https://s3.amazonaws.com/' + bucket + '/';
-            return base + options.getUploadPath();
-		}
+            return options.getBaseLocation() + options.getUploadPath();
+        }
 	};
 }
 

--- a/test/optionsValidator.js
+++ b/test/optionsValidator.js
@@ -58,7 +58,7 @@ describe( 'options validator', function() {
 
 		it( 'should return specified devTag', function() {
 			var releaseOptions = optionsValidator(
-				{	
+				{
 					id: 'myId',
 					devTag: 'some-tag',
 					initialPath: 'path/',
@@ -70,7 +70,7 @@ describe( 'options validator', function() {
 
 		it( 'should return specified version', function() {
 			var releaseOptions = optionsValidator(
-				{	
+				{
 					id: 'myId',
 					version: '1.2.0',
 					initialPath: 'path/',
@@ -113,16 +113,14 @@ describe( 'options validator', function() {
             var options = optionsValidator(
                 { id: "id", devTag: "devTag", creds: { key: "key", secret: "mySecret" } }
             );
-            expect(options.getCreds()).to.include.keys("bucket");
-            expect(options.getCreds().bucket).to.equal("d2lprodcdn");
+            expect(options.getCreds()).to.have.property('bucket', 'd2lprodcdn');
         } );
 
         it( 'should set bucket to provided bucket when one provided', function() {
             var options = optionsValidator(
                 { id: "id", devTag: "devTag", creds: { key: "key", secret: "mySecret", bucket: "test-bucket" } }
             );
-            expect( options.getCreds() ).to.include.keys("bucket");
-            expect( options.getCreds().bucket ).to.equal("test-bucket");
+            expect( options.getCreds() ).to.have.property('bucket', 'test-bucket');
         } );
 
 		it( 'should return specified creds', function() {
@@ -158,7 +156,7 @@ describe( 'options validator', function() {
 
 		it( 'should return valid release upload path', function() {
 			var releaseOptions = optionsValidator(
-				{	
+				{
 					id: 'myId',
 					version: '1.2.0',
 					initialPath: 'path/',
@@ -171,7 +169,7 @@ describe( 'options validator', function() {
 
 		it( 'should prioritize release version over devTag', function() {
 			var options = optionsValidator(
-				{	
+				{
 					id: 'myId',
 					devTag: 'tag',
 					version: '2.2.0',

--- a/test/optionsValidator.js
+++ b/test/optionsValidator.js
@@ -133,6 +133,22 @@ describe( 'options validator', function() {
 
 	} );
 
+	describe( 'getBaseLocation', function() {
+        it( 'should return the production CDN when no bucket provided', function() {
+            var options = optionsValidator(
+                { id: "id", devTag: "devTag", creds: { key: "key", secret: "mySecret" } }
+            );
+            expect( options.getBaseLocation() ).to.equal('https://s.brightspace.com/');
+        } );
+
+        it( 'should return the AWS bucket location when a bucket is provided', function() {
+            var options = optionsValidator(
+                { id: "id", devTag: "devTag", creds: { key: "key", secret: "mySecret", bucket: "test-bucket" } }
+            );
+            expect( options.getBaseLocation() ).to.equal('https://s3.amazonaws.com/test-bucket/');
+        } );
+	} );
+
 	describe( 'getUploadPath', function() {
 
 		it( 'should return valid development upload path', function() {

--- a/test/optionsValidator.js
+++ b/test/optionsValidator.js
@@ -145,6 +145,20 @@ describe( 'options validator', function() {
             );
             expect( options.getBaseLocation() ).to.equal('https://s3.amazonaws.com/test-bucket/');
         } );
+
+        it( 'should return the production CDN when the production bucket name is provided', function() {
+            var options = optionsValidator(
+                { id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret', bucket: 'd2lprodcdn' } }
+            );
+            expect( options.getBaseLocation() ).to.equal('https://s.brightspace.com/');
+        } );
+
+        it( 'should return the production CDN when an empty bucket name is provided', function() {
+            var options = optionsValidator(
+                { id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret', bucket: '' } }
+            );
+            expect( options.getBaseLocation() ).to.equal('https://s.brightspace.com/');
+        } );
 	} );
 
 	describe( 'getUploadPath', function() {

--- a/test/optionsValidator.js
+++ b/test/optionsValidator.js
@@ -109,6 +109,22 @@ describe( 'options validator', function() {
 				} ).to.throw( 'Missing credential secret' );
 		} );
 
+        it( 'should set bucket to production cdn when none provided', function() {
+            var options = optionsValidator(
+                { id: "id", devTag: "devTag", creds: { key: "key", secret: "mySecret" } }
+            );
+            expect(options.getCreds()).to.include.keys("bucket");
+            expect(options.getCreds().bucket).to.equal("d2lprodcdn");
+        } );
+
+        it( 'should set bucket to provided bucket when one provided', function() {
+            var options = optionsValidator(
+                { id: "id", devTag: "devTag", creds: { key: "key", secret: "mySecret", bucket: "test-bucket" } }
+            );
+            expect( options.getCreds() ).to.include.keys("bucket");
+            expect( options.getCreds().bucket ).to.equal("test-bucket");
+        } );
+
 		it( 'should return specified creds', function() {
 
 			expect( validOptions.getCreds().key ).to.equal( 'myKey' );

--- a/test/optionsValidator.js
+++ b/test/optionsValidator.js
@@ -109,19 +109,19 @@ describe( 'options validator', function() {
 				} ).to.throw( 'Missing credential secret' );
 		} );
 
-        it( 'should set bucket to production cdn when none provided', function() {
-            var options = optionsValidator(
-                { id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret' } }
-            );
-            expect(options.getCreds()).to.have.property('bucket', 'd2lprodcdn');
-        } );
+		it( 'should set bucket to production cdn when none provided', function() {
+			var options = optionsValidator(
+				{ id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret' } }
+			);
+			expect(options.getCreds()).to.have.property('bucket', 'd2lprodcdn');
+		} );
 
-        it( 'should set bucket to provided bucket when one provided', function() {
-            var options = optionsValidator(
-                { id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret', testBucket: 'test-bucket' } }
-            );
-            expect( options.getCreds() ).to.have.property('bucket', 'test-bucket');
-        } );
+		it( 'should set bucket to provided bucket when one provided', function() {
+			var options = optionsValidator(
+				{ id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret', testBucket: 'test-bucket' } }
+			);
+			expect( options.getCreds() ).to.have.property('bucket', 'test-bucket');
+		} );
 
 		it( 'should return specified creds', function() {
 
@@ -132,33 +132,33 @@ describe( 'options validator', function() {
 	} );
 
 	describe( 'getBaseLocation', function() {
-        it( 'should return the production CDN when no bucket provided', function() {
-            var options = optionsValidator(
-                { id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret' } }
-            );
-            expect( options.getBaseLocation() ).to.equal('https://s.brightspace.com/');
-        } );
+		it( 'should return the production CDN when no bucket provided', function() {
+			var options = optionsValidator(
+				{ id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret' } }
+			);
+			expect( options.getBaseLocation() ).to.equal('https://s.brightspace.com/');
+		} );
 
-        it( 'should return the AWS bucket location when a bucket is provided', function() {
-            var options = optionsValidator(
-                { id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret', testBucket: 'test-bucket' } }
-            );
-            expect( options.getBaseLocation() ).to.equal('https://s3.amazonaws.com/test-bucket/');
-        } );
+		it( 'should return the AWS bucket location when a bucket is provided', function() {
+			var options = optionsValidator(
+				{ id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret', testBucket: 'test-bucket' } }
+			);
+			expect( options.getBaseLocation() ).to.equal('https://s3.amazonaws.com/test-bucket/');
+		} );
 
-        it( 'should return the production CDN when the production bucket name is provided', function() {
-            var options = optionsValidator(
-                { id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret', testBucket: 'd2lprodcdn' } }
-            );
-            expect( options.getBaseLocation() ).to.equal('https://s.brightspace.com/');
-        } );
+		it( 'should return the production CDN when the production bucket name is provided', function() {
+			var options = optionsValidator(
+				{ id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret', testBucket: 'd2lprodcdn' } }
+			);
+			expect( options.getBaseLocation() ).to.equal('https://s.brightspace.com/');
+		} );
 
-        it( 'should return the production CDN when an empty bucket name is provided', function() {
-            var options = optionsValidator(
-                { id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret', testBucket: '' } }
-            );
-            expect( options.getBaseLocation() ).to.equal('https://s.brightspace.com/');
-        } );
+		it( 'should return the production CDN when an empty bucket name is provided', function() {
+			var options = optionsValidator(
+				{ id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret', testBucket: '' } }
+			);
+			expect( options.getBaseLocation() ).to.equal('https://s.brightspace.com/');
+		} );
 	} );
 
 	describe( 'getUploadPath', function() {

--- a/test/optionsValidator.js
+++ b/test/optionsValidator.js
@@ -113,14 +113,14 @@ describe( 'options validator', function() {
             var options = optionsValidator(
                 { id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret' } }
             );
-            expect(options.getCreds()).to.have.property('testBucket', 'd2lprodcdn');
+            expect(options.getCreds()).to.have.property('bucket', 'd2lprodcdn');
         } );
 
         it( 'should set bucket to provided bucket when one provided', function() {
             var options = optionsValidator(
                 { id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret', testBucket: 'test-bucket' } }
             );
-            expect( options.getCreds() ).to.have.property('testBucket', 'test-bucket');
+            expect( options.getCreds() ).to.have.property('bucket', 'test-bucket');
         } );
 
 		it( 'should return specified creds', function() {

--- a/test/optionsValidator.js
+++ b/test/optionsValidator.js
@@ -111,14 +111,14 @@ describe( 'options validator', function() {
 
         it( 'should set bucket to production cdn when none provided', function() {
             var options = optionsValidator(
-                { id: "id", devTag: "devTag", creds: { key: "key", secret: "mySecret" } }
+                { id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret' } }
             );
             expect(options.getCreds()).to.have.property('bucket', 'd2lprodcdn');
         } );
 
         it( 'should set bucket to provided bucket when one provided', function() {
             var options = optionsValidator(
-                { id: "id", devTag: "devTag", creds: { key: "key", secret: "mySecret", bucket: "test-bucket" } }
+                { id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret', bucket: 'test-bucket' } }
             );
             expect( options.getCreds() ).to.have.property('bucket', 'test-bucket');
         } );
@@ -134,14 +134,14 @@ describe( 'options validator', function() {
 	describe( 'getBaseLocation', function() {
         it( 'should return the production CDN when no bucket provided', function() {
             var options = optionsValidator(
-                { id: "id", devTag: "devTag", creds: { key: "key", secret: "mySecret" } }
+                { id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret' } }
             );
             expect( options.getBaseLocation() ).to.equal('https://s.brightspace.com/');
         } );
 
         it( 'should return the AWS bucket location when a bucket is provided', function() {
             var options = optionsValidator(
-                { id: "id", devTag: "devTag", creds: { key: "key", secret: "mySecret", bucket: "test-bucket" } }
+                { id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret', bucket: 'test-bucket' } }
             );
             expect( options.getBaseLocation() ).to.equal('https://s3.amazonaws.com/test-bucket/');
         } );

--- a/test/optionsValidator.js
+++ b/test/optionsValidator.js
@@ -113,14 +113,14 @@ describe( 'options validator', function() {
             var options = optionsValidator(
                 { id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret' } }
             );
-            expect(options.getCreds()).to.have.property('bucket', 'd2lprodcdn');
+            expect(options.getCreds()).to.have.property('testBucket', 'd2lprodcdn');
         } );
 
         it( 'should set bucket to provided bucket when one provided', function() {
             var options = optionsValidator(
-                { id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret', bucket: 'test-bucket' } }
+                { id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret', testBucket: 'test-bucket' } }
             );
-            expect( options.getCreds() ).to.have.property('bucket', 'test-bucket');
+            expect( options.getCreds() ).to.have.property('testBucket', 'test-bucket');
         } );
 
 		it( 'should return specified creds', function() {
@@ -141,21 +141,21 @@ describe( 'options validator', function() {
 
         it( 'should return the AWS bucket location when a bucket is provided', function() {
             var options = optionsValidator(
-                { id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret', bucket: 'test-bucket' } }
+                { id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret', testBucket: 'test-bucket' } }
             );
             expect( options.getBaseLocation() ).to.equal('https://s3.amazonaws.com/test-bucket/');
         } );
 
         it( 'should return the production CDN when the production bucket name is provided', function() {
             var options = optionsValidator(
-                { id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret', bucket: 'd2lprodcdn' } }
+                { id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret', testBucket: 'd2lprodcdn' } }
             );
             expect( options.getBaseLocation() ).to.equal('https://s.brightspace.com/');
         } );
 
         it( 'should return the production CDN when an empty bucket name is provided', function() {
             var options = optionsValidator(
-                { id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret', bucket: '' } }
+                { id: 'id', devTag: 'devTag', creds: { key: 'key', secret: 'mySecret', testBucket: '' } }
             );
             expect( options.getBaseLocation() ).to.equal('https://s.brightspace.com/');
         } );

--- a/test/publisher.js
+++ b/test/publisher.js
@@ -18,7 +18,7 @@ var options = {
 
 var optionsWithBucket = {
     id: 'myId',
-    creds: { key: 'myKey', secret: 'mySecret', bucket: 'test-bucket' },
+    creds: { key: 'myKey', secret: 'mySecret', testBucket: 'test-bucket' },
     devTag: 'myDevTag'
 };
 

--- a/test/publisher.js
+++ b/test/publisher.js
@@ -17,9 +17,9 @@ var options = {
 	};
 
 var optionsWithBucket = {
-    id: 'myId',
-    creds: { key: 'myKey', secret: 'mySecret', testBucket: 'test-bucket' },
-    devTag: 'myDevTag'
+	id: 'myId',
+	creds: { key: 'myKey', secret: 'mySecret', testBucket: 'test-bucket' },
+	devTag: 'myDevTag'
 };
 
 describe('publisher', function () {
@@ -31,9 +31,9 @@ describe('publisher', function () {
 	['app','lib'].forEach( function( val ) {
 
 		describe( val + '.getLocation', function () {
-            var urlVal = ( val === 'app' ) ? 'apps' : val;
+			var urlVal = ( val === 'app' ) ? 'apps' : val;
 
-            it( 'should return the proper address when no bucket name provided', function () {
+			it( 'should return the proper address when no bucket name provided', function () {
 				var location = publisher[val]( options ).getLocation();
 				expect( location ).to.equal(
 						'https://s.brightspace.com/' + urlVal + '/myId/dev/myDevTag/'
@@ -41,13 +41,13 @@ describe('publisher', function () {
 
 			});
 
-            it( 'should return the proper address when a bucket name is provided', function () {
-                var location = publisher[val]( optionsWithBucket ).getLocation();
-                expect( location ).to.equal(
-                    'https://s3.amazonaws.com/test-bucket/' + urlVal + '/myId/dev/myDevTag/'
-                );
+			it( 'should return the proper address when a bucket name is provided', function () {
+				var location = publisher[val]( optionsWithBucket ).getLocation();
+				expect( location ).to.equal(
+					'https://s3.amazonaws.com/test-bucket/' + urlVal + '/myId/dev/myDevTag/'
+				);
 
-            });
+			});
 
 		} );
 

--- a/test/publisher.js
+++ b/test/publisher.js
@@ -16,6 +16,12 @@ var options = {
 		devTag: 'myDevTag'
 	};
 
+var optionsWithBucket = {
+    id: 'myId',
+    creds: { key: 'myKey', secret: 'mySecret', bucket: 'test-bucket' },
+    devTag: 'myDevTag'
+};
+
 describe('publisher', function () {
 
 	beforeEach( function() {
@@ -36,9 +42,7 @@ describe('publisher', function () {
 			});
 
             it( 'should return the proper address when a bucket name is provided', function () {
-                var bucketOptions = JSON.parse(JSON.stringify(options)); // to clone the object
-                bucketOptions.creds.bucket = 'test-bucket';
-                var location = publisher[val]( bucketOptions ).getLocation();
+                var location = publisher[val]( optionsWithBucket ).getLocation();
                 var urlVal = ( val === 'app' ) ? 'apps' : val;
                 expect( location ).to.equal(
                     'https://s3.amazonaws.com/test-bucket/' + urlVal + '/myId/dev/myDevTag/'

--- a/test/publisher.js
+++ b/test/publisher.js
@@ -31,10 +31,10 @@ describe('publisher', function () {
 	['app','lib'].forEach( function( val ) {
 
 		describe( val + '.getLocation', function () {
+            var urlVal = ( val === 'app' ) ? 'apps' : val;
 
-			it( 'should return the proper address when no bucket name provided', function () {
+            it( 'should return the proper address when no bucket name provided', function () {
 				var location = publisher[val]( options ).getLocation();
-				var urlVal = ( val === 'app' ) ? 'apps' : val;
 				expect( location ).to.equal(
 						'https://s.brightspace.com/' + urlVal + '/myId/dev/myDevTag/'
 					);
@@ -43,7 +43,6 @@ describe('publisher', function () {
 
             it( 'should return the proper address when a bucket name is provided', function () {
                 var location = publisher[val]( optionsWithBucket ).getLocation();
-                var urlVal = ( val === 'app' ) ? 'apps' : val;
                 expect( location ).to.equal(
                     'https://s3.amazonaws.com/test-bucket/' + urlVal + '/myId/dev/myDevTag/'
                 );

--- a/test/publisher.js
+++ b/test/publisher.js
@@ -26,7 +26,7 @@ describe('publisher', function () {
 
 		describe( val + '.getLocation', function () {
 
-			it( 'should return the proper address', function () {
+			it( 'should return the proper address when no bucket name provided', function () {
 				var location = publisher[val]( options ).getLocation();
 				var urlVal = ( val === 'app' ) ? 'apps' : val;
 				expect( location ).to.equal(
@@ -34,6 +34,17 @@ describe('publisher', function () {
 					);
 
 			});
+
+            it( 'should return the proper address when a bucket name is provided', function () {
+                var bucketOptions = JSON.parse(JSON.stringify(options)); // to clone the object
+                bucketOptions.creds.bucket = 'test-bucket';
+                var location = publisher[val]( bucketOptions ).getLocation();
+                var urlVal = ( val === 'app' ) ? 'apps' : val;
+                expect( location ).to.equal(
+                    'https://s3.amazonaws.com/test-bucket/' + urlVal + '/myId/dev/myDevTag/'
+                );
+
+            });
 
 		} );
 


### PR DESCRIPTION
Added parameterization to the CDN functionality. If no bucket name is provided in the creds object, it will default to the production CDN, so existing functionality will be preserved. If a bucket name is provided, however, it will function as if it is publishing to some other S3 bucket.

*Reasoning*: This was done in order to allow testing free-range apps without having to upload the apps to the production CDN. Buckets can be created strictly for testing purposes so that the production CDN can stay production-only,