### PR TITLE
Update publisher option API for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![NPM version][npm-image]][npm-url]
 [![Build status][ci-image]][ci-url]
 [![Coverage Status][coverage-image]][coverage-url]
+[![Dependency Status][dependencies-image]][dependencies-url]
 
 A utility for publishing free-range applications and libraries to our CDN
 using [Gulp](http://www.gulpjs.com).
@@ -85,8 +86,10 @@ var location = appPublisher.getLocation();
 ```
 
 [npm-url]: https://npmjs.org/package/gulp-frau-publisher
-[npm-image]: https://badge.fury.io/js/gulp-frau-publisher.png
+[npm-image]: https://img.shields.io/npm/v/gulp-frau-publisher.svg
 [ci-image]: https://travis-ci.org/Brightspace/gulp-frau-publisher.svg?branch=master
 [ci-url]: https://travis-ci.org/Brightspace/gulp-frau-publisher
 [coverage-image]: https://img.shields.io/coveralls/Brightspace/gulp-frau-publisher.svg
 [coverage-url]: https://coveralls.io/r/Brightspace/gulp-frau-publisher?branch=master
+[dependencies-url]: https://david-dm.org/brightspace/gulp-frau-publisher
+[dependencies-image]: https://img.shields.io/david/Brightspace/gulp-frau-publisher.svg

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To publish a free-range application to the CDN:
 var publisher = require('gulp-frau-publisher');
 
 var options = {
-	id: 'someID',
+	targetDirectory: 'someDirectory',
 	creds: {
 		"key": "AKITHISISSOMEKEYASDF",
 		"secret": "aCD233rDF232RANDOMSECRET12+32g"
@@ -55,7 +55,7 @@ In your `options` variable, set the `version` tag with a valid version:
 
 ```javascript
 var options = {
-	id: 'someID',
+	targetDirectory: 'someDirectory',
 	creds: {
 		"key": "AKITHISISSOMEKEYASDF",
 		"secret": "aCD233rDF232RANDOMSECRET12+32g"
@@ -68,11 +68,11 @@ var options = {
 Both the `app()` and `lib()` publisher methods accept the following options:
 
 | Property | Description |
-| ------------- | ----------- |
-| id            | Unique name of the app or library. |
-| creds         | Credentials key/secret for the specified app. Do **not** commit the secret to source control. Either load it from a file (which is excluded from source control) or use an environment or command-line variable. |
-| devTag        | The development version of the app or library. |
-| version       | The released/production version of the app or library. Unlike devTag, this property must follow the guidelines in [Semantic Versioning](http://semver.org). |
+| --------------- | ----------- |
+| targetDirectory | Unique target directory where the app or library will be published. |
+| creds           | Credentials key/secret for the specified app. Do **not** commit the secret to source control. Either load it from a file (which is excluded from source control) or use an environment or command-line variable. |
+| devTag          | The development version of the app or library. |
+| version         | The released/production version of the app or library. Unlike devTag, this property must follow the guidelines in [Semantic Versioning](http://semver.org). |
 
 
 ### Get the app's location

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "event-stream": "^3.1.7",
+    "chalk": "^1.1.0",
     "gulp-s3": "^0.3.0",
     "gulp-util": "^3.0.1",
     "knox": "^0.9.1",

--- a/src/optionsValidator.js
+++ b/src/optionsValidator.js
@@ -1,5 +1,7 @@
 'use strict';
-var semver = require('semver');
+
+var chalk = require('chalk'),
+	semver = require('semver');
 
 function validateOpts ( opts ) {
 	if( !opts ) {
@@ -20,12 +22,18 @@ module.exports = function( opts ) {
 
 	var options = {
 
-		getId: function() {
+		getTargetDirectory: function() {
 			validateOpts( opts );
-			if( !opts.id ) {
-				throw new Error('Missing id');
+			if( !opts.targetDirectory && !opts.id ) {
+				throw new Error('Missing targetDirectory');
 			}
-			return opts.id;
+			if( opts.id ) {
+				console.log(chalk.red('The targetDirectory should be specified on options rather than id.  Specifying targetDirectory via id will not be supported in a future release.'));
+			}
+			if ( !opts.targetDirectory && opts.id ) {
+				opts.targetDirectory = opts.id;
+			}
+			return opts.targetDirectory;
 		},
 
 		getVersion: function () {
@@ -65,7 +73,7 @@ module.exports = function( opts ) {
 			validateOpts( opts );
 			var devPath = getDevPath( opts );
 			// version gets priority over devTag
-			return opts.initialPath + this.getId() + devPath +
+			return opts.initialPath + this.getTargetDirectory() + devPath +
 				this.getVersion() + '/';
 		}
 

--- a/test/optionsValidator.js
+++ b/test/optionsValidator.js
@@ -2,13 +2,21 @@ var optionsValidator = require('../src/optionsValidator');
 
 var validOptions = optionsValidator(
 	{
-		id: 'myId',
+		targetDirectory: 'myTargetDirectory',
 		devTag: 'myDevTag',
 		initialPath: 'path/',
 		creds: { key: 'myKey', secret: 'mySecret' }
 	}
 );
 
+var obsoleteValidOptions = optionsValidator(
+	{
+		id: 'myTargetDirectory',
+		devTag: 'myDevTag',
+		initialPath: 'path/',
+		creds: { key: 'myKey', secret: 'mySecret' }
+	}
+);
 
 
 describe( 'options validator', function() {
@@ -17,25 +25,29 @@ describe( 'options validator', function() {
 
 		it( 'should throw with undefined options', function() {
 			var options = optionsValidator();
-			expect( function() { options.getId(); } ).to.throw( 'Missing options' );
+			expect( function() { options.getTargetDirectory(); } ).to.throw( 'Missing options' );
 		} );
 
 		it( 'should throw with null options', function() {
 			var options = optionsValidator( null );
-			expect( function() { options.getId(); } ).to.throw( 'Missing options' );
+			expect( function() { options.getTargetDirectory(); } ).to.throw( 'Missing options' );
 		} );
 
 	} );
 
-	describe( 'id', function() {
+	describe( 'targetDirectory', function() {
 
-		it( 'should throw with no id', function() {
+		it( 'should throw with no targetDirectory', function() {
 			var options = optionsValidator({});
-			expect( function() { options.getId(); } ).to.throw( 'Missing id' );
+			expect( function() { options.getTargetDirectory(); } ).to.throw( 'Missing targetDirectory' );
 		} );
 
-		it( 'should return specified id', function() {
-			expect( validOptions.getId() ).to.equal( 'myId' );
+		it( 'should return specified targetDirectory', function() {
+			expect( validOptions.getTargetDirectory() ).to.equal( 'myTargetDirectory' );
+		} );
+
+		it( 'should return specified id as targetDirectory when targetDirectory not specified', function() {
+			expect( obsoleteValidOptions.getTargetDirectory() ).to.equal( 'myTargetDirectory' );
 		} );
 
 	} );
@@ -43,14 +55,14 @@ describe( 'options validator', function() {
 	describe( 'version', function() {
 
 		it( 'should throw with no devTag and no version', function() {
-			var options = optionsValidator( { id: 'id' } );
+			var options = optionsValidator( { targetDirectory: 'myTargetDirectory' } );
 			expect( function() {
 					options.getVersion();
 				} ).to.throw( 'Missing version' );
 		} );
 
 		it( 'should throw with wrong semantic version', function() {
-			var options = optionsValidator( { id: 'id', version: '1.2.3.4' } );
+			var options = optionsValidator( { targetDirectory: 'myTargetDirectory', version: '1.2.3.4' } );
 			expect( function() {
 					options.getVersion();
 				} ).to.throw( '"1.2.3.4" is not a valid version number. See semver.org for more details.' );
@@ -59,7 +71,7 @@ describe( 'options validator', function() {
 		it( 'should return specified devTag', function() {
 			var releaseOptions = optionsValidator(
 				{	
-					id: 'myId',
+					targetDirectory: 'myTargetDirectory',
 					devTag: 'some-tag',
 					initialPath: 'path/',
 					creds: { key: 'myKey', secret: 'mySecret' }
@@ -71,7 +83,7 @@ describe( 'options validator', function() {
 		it( 'should return specified version', function() {
 			var releaseOptions = optionsValidator(
 				{	
-					id: 'myId',
+					targetDirectory: 'myTargetDirectory',
 					version: '1.2.0',
 					initialPath: 'path/',
 					creds: { key: 'myKey', secret: 'mySecret' }
@@ -85,7 +97,7 @@ describe( 'options validator', function() {
 	describe( 'creds', function() {
 
 		it( 'should throw with no credentials', function() {
-			var options = optionsValidator( { id: 'id', devTag: 'tag' } );
+			var options = optionsValidator( { targetDirectory: 'myTargetDirectory', devTag: 'tag' } );
 			expect( function() {
 					options.getCreds();
 				} ).to.throw( 'Missing credentials' );
@@ -93,7 +105,7 @@ describe( 'options validator', function() {
 
 		it( 'should throw with no credentials key', function() {
 			var options = optionsValidator(
-				{ id: 'id', devTag: 'tag', creds: {} }
+				{ targetDirectory: 'myTargetDirectory', devTag: 'tag', creds: {} }
 			);
 			expect( function() {
 					options.getCreds();
@@ -102,7 +114,7 @@ describe( 'options validator', function() {
 
 		it( 'should throw with no credentials secret', function() {
 			var options = optionsValidator(
-				{ id: "id", devTag: "devTag", creds: { key: "key" } }
+				{ targetDirectory: "myTargetDirectory", devTag: "devTag", creds: { key: "key" } }
 			);
 			expect( function() {
 					options.getCreds();
@@ -121,26 +133,26 @@ describe( 'options validator', function() {
 
 		it( 'should return valid development upload path', function() {
 			expect( validOptions.getUploadPath() )
-				.to.equal( 'path/myId/dev/myDevTag/' );
+				.to.equal( 'path/myTargetDirectory/dev/myDevTag/' );
 		} );
 
 		it( 'should return valid release upload path', function() {
 			var releaseOptions = optionsValidator(
 				{	
-					id: 'myId',
+					targetDirectory: 'myTargetDirectory',
 					version: '1.2.0',
 					initialPath: 'path/',
 					creds: { key: 'myKey', secret: 'mySecret' }
 				}
 			);
 			expect( releaseOptions.getUploadPath() )
-				.to.equal( 'path/myId/1.2.0/' );
+				.to.equal( 'path/myTargetDirectory/1.2.0/' );
 		} );
 
 		it( 'should prioritize release version over devTag', function() {
 			var options = optionsValidator(
 				{	
-					id: 'myId',
+					targetDirectory: 'myTargetDirectory',
 					devTag: 'tag',
 					version: '2.2.0',
 					initialPath: 'path/',
@@ -148,7 +160,7 @@ describe( 'options validator', function() {
 				}
 			);
 			expect( options.getUploadPath() )
-				.to.equal( 'path/myId/2.2.0/' );
+				.to.equal( 'path/myTargetDirectory/2.2.0/' );
 		} );
 
 	} );

--- a/test/publisher.js
+++ b/test/publisher.js
@@ -11,7 +11,7 @@ var publisher = proxyquire('../src/publisher', {
 } );
 
 var options = {
-		id: 'myId',
+		targetDirectory: 'myTargetDirectory',
 		creds: { key: 'myKey', secret: 'mySecret' },
 		devTag: 'myDevTag'
 	};
@@ -30,7 +30,7 @@ describe('publisher', function () {
 				var location = publisher[val]( options ).getLocation();
 				var urlVal = ( val === 'app' ) ? 'apps' : val;
 				expect( location ).to.equal(
-						'https://s.brightspace.com/' + urlVal + '/myId/dev/myDevTag/'
+						'https://s.brightspace.com/' + urlVal + '/myTargetDirectory/dev/myDevTag/'
 					);
 
 			});
@@ -54,7 +54,7 @@ describe('publisher', function () {
 				headers: {
 					'cache-control': 'public, max-age=31536000'
 				},
-				uploadPath: 'path/myId/dev/myDevTag/'
+				uploadPath: 'path/myTargetDirectory/dev/myDevTag/'
 			};
 			var stream = publisher._helper(options, 'path/').getStream();
 			expect(s3).to.be.calledWith(sinon.match.any, expectedOptions);


### PR DESCRIPTION
With these changes, `targetDirectory` will be the preferred option rather than `id`.  The `id` parameter will still be accepted if `targetDirectory` is not provided, but a message will be logged indicating the preferred property.  Readme and tests updated accordingly.

@dlockhart - was there other stuff you wanted updating for this?

Note: David identified the semver vulnerability - I will update that in a separate change.